### PR TITLE
Fix #6, remove Yarn deprecation warning

### DIFF
--- a/lib/parcel/rails/parcel_generator.rb
+++ b/lib/parcel/rails/parcel_generator.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
+require 'rails/generators'
 
 class ParcelGenerator < ::Rails::Generators::Base
-  desc 'Generate parce-rails initializer'
+  desc 'Generate parcel-rails initializer'
 
   def create_initializer_file
     initializer 'parcel.rb' do

--- a/lib/parcel/rails/runner.rb
+++ b/lib/parcel/rails/runner.rb
@@ -31,7 +31,7 @@ module Parcel
       private
 
       def parcel_commmand(cmd = '')
-        command = "yarn run parcel -- #{cmd} #{@args.join(' ')}"
+        command = "yarn run parcel #{cmd} #{@args.join(' ')}"
         output = exec(command)
       end
     end


### PR DESCRIPTION
# What's New?

 * Fix runtime error caused by missing `Rails::Generators` const.
 * Fix deprecation warning due to `--` usage in Yarn > 1.0.0

Please let me know if it needs any changes. Thanks!